### PR TITLE
Fix Animation Bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /*.rbxlx.lock
 /*.rbxl.lock
 
+.vscode/
 build
 Packages/
 sourcemap.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.3.1
+### Fixed
+
+- Fixed bug where walking animation would break when movement input was pressed before deactivating ragdoll physics.
+- Fixed bug where fall animation would play while ragdolled if ragdoll physics was activated during humanoid Jumping state.
+
 ## 0.3.0
 ### Changed
 

--- a/lib/RagdollFactory/Ragdoll.lua
+++ b/lib/RagdollFactory/Ragdoll.lua
@@ -156,14 +156,6 @@ function Ragdoll.new(character: Model, blueprint)
 		return blueprint.lowDetailModeLimbs[(motor.Part1 :: BasePart).Name]
 	end)
 
-	trove:Connect(self.Humanoid.StateChanged, function(_old, new)
-		if self:isRagdolled() and new == Enum.HumanoidStateType.Physics then
-			for _, track: AnimationTrack in self.Animator:GetPlayingAnimationTracks() do
-				track:Stop()
-			end
-		end
-	end)
-
 	self.RagdollBegan:Connect(function()
 		character:SetAttribute("Ragdolled", true)
 	end)
@@ -299,9 +291,14 @@ end
 
 --@ignore
 function Ragdoll._activateRagdollPhysics(ragdoll, accessoryHandles, motor6Ds, limbs, noCollisionConstraints, sockets)
+	if ragdoll._ragdolled then
+		return
+	end
+
+	ragdoll._ragdolled = true
 	ragdoll.Humanoid.WalkSpeed = 0
 	ragdoll.Humanoid.AutoRotate = false
-	ragdoll.Humanoid:ChangeState(Enum.HumanoidStateType.Physics)
+	ragdoll.Humanoid:ChangeState(Enum.HumanoidStateType.FallingDown)
 	ragdoll.HumanoidRootPart.CanCollide = false
 	ragdoll.HumanoidRootPart.CustomPhysicalProperties = ROOT_PART_PHYSICAL_PROPERTIES
 
@@ -335,11 +332,6 @@ end
 	Activates ragdoll physics.
 ]=]
 function Ragdoll:activateRagdollPhysics()
-	if self._ragdolled then
-		return
-	end
-
-	self._ragdolled = true
 	Ragdoll._activateRagdollPhysics(
 		self,
 		self._accessoryHandles,
@@ -354,11 +346,6 @@ end
 	Activates ragdoll physics in low detail mode.
 ]=]
 function Ragdoll:activateRagdollPhysicsLowDetail()
-	if self._ragdolled then
-		return
-	end
-
-	self._ragdolled = true
 	Ragdoll._activateRagdollPhysics(
 		self,
 		self._accessoryHandles,

--- a/lib/RagdollFactory/ReplicatedRagdoll.lua
+++ b/lib/RagdollFactory/ReplicatedRagdoll.lua
@@ -62,14 +62,6 @@ function ReplicatedRagdoll.new(character: Model, blueprint): Ragdoll.Ragdoll
 		return blueprint.lowDetailModeLimbs[(motor.Part1 :: BasePart).Name]
 	end)
 
-	trove:Connect(self.Humanoid.StateChanged, function(_old, new)
-		if self:isRagdolled() and new == Enum.HumanoidStateType.Physics then
-			for _, track: AnimationTrack in self.Animator:GetPlayingAnimationTracks() do
-				track:Stop()
-			end
-		end
-	end)
-
 	return self
 end
 

--- a/lib/init.lua
+++ b/lib/init.lua
@@ -227,6 +227,12 @@ function registerEvents(ragdoll)
 		end
 	end)
 
+	ragdoll._trove:Connect(ragdoll.Humanoid.StateChanged, function(_old, new)
+		if new == Enum.HumanoidStateType.FallingDown and ragdoll:isRagdolled() then
+			ragdoll.Humanoid:ChangeState(Enum.HumanoidStateType.Physics)
+		end
+	end)
+
 	ragdoll._trove:Connect(ragdoll.Humanoid.Died, function()
 		RagdollSystem:collapseRagdoll(ragdoll.Character)
 	end)

--- a/wally.lock
+++ b/wally.lock
@@ -4,8 +4,8 @@ registry = "test"
 
 [[package]]
 name = "leostormer/ragdoll-system"
-version = "0.1.0"
-dependencies = [["Signal", "sleitnick/signal@1.5.0"], ["Trove", "sleitnick/trove@0.5.0"]]
+version = "0.3.1"
+dependencies = [["Signal", "sleitnick/signal@1.5.0"], ["Trove", "sleitnick/trove@1.0.0"]]
 
 [[package]]
 name = "sleitnick/signal"
@@ -14,5 +14,5 @@ dependencies = []
 
 [[package]]
 name = "sleitnick/trove"
-version = "0.5.0"
+version = "1.0.0"
 dependencies = []

--- a/wally.toml
+++ b/wally.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leostormer/ragdoll-system"
-version = "0.3.0"
+version = "0.3.1"
 registry = "https://github.com/UpliftGames/wally-index"
 realm = "shared"
 liscense = "MIT"
@@ -10,4 +10,4 @@ exclude = ["dev", "docs", "roblox.yml", "selene.toml", "moonwave.toml", "dev.pro
 
 [dependencies]
 Signal = "sleitnick/signal@1.5.0"
-Trove = "sleitnick/trove@0.5.0"
+Trove = "sleitnick/trove@1.0.0"


### PR DESCRIPTION
This fixes an animation bug that closes #1 and closes #2; it was caused by the method that was being used to cancel animations when ragdoll physics was being activated. Before, all of a character's currently playing animations were obtained by calling Animator:GetPlayingAnimationTracks(), looping through the list, and calling AnimationTrack:Stop() on each one. This was causing a conflict with the Default Roblox Animate script.
After looking through the Animate script, animations are automatically stopped when the humanoid enters the FallingDown State. Therefore, when ragdoll physics is activated, the humanoid is set to the FallingDown state, and when the humanoid enters FallingDown, then it is set to Physics state.