### PR TITLE
Fix density warning

### DIFF
--- a/lib/RagdollFactory/Ragdoll.lua
+++ b/lib/RagdollFactory/Ragdoll.lua
@@ -60,7 +60,7 @@ local Ragdoll = {}
 Ragdoll.__index = Ragdoll
 
 local LIMB_PHYSICAL_PROPERTIES = PhysicalProperties.new(5, 0.7, 0.5, 100, 100)
-local ROOT_PART_PHYSICAL_PROPERTIES = PhysicalProperties.new(0, 0, 0, 0, 0)
+local ROOT_PART_PHYSICAL_PROPERTIES = PhysicalProperties.new(0.01, 0, 0, 0, 0)
 -- local RAGDOLL_TIMEOUT_INTERVAL = 1.5
 -- local RAGDOLL_TIMEOUT_DISTANCE_THRESHOLD = 2
 

--- a/wally.lock
+++ b/wally.lock
@@ -4,7 +4,7 @@ registry = "test"
 
 [[package]]
 name = "leostormer/ragdoll-system"
-version = "0.3.3"
+version = "0.3.4"
 dependencies = [["Signal", "sleitnick/signal@2.0.1"], ["Trove", "sleitnick/trove@1.0.1"]]
 
 [[package]]

--- a/wally.lock
+++ b/wally.lock
@@ -5,11 +5,11 @@ registry = "test"
 [[package]]
 name = "leostormer/ragdoll-system"
 version = "0.3.3"
-dependencies = [["Signal", "sleitnick/signal@1.5.0"], ["Trove", "sleitnick/trove@1.0.1"]]
+dependencies = [["Signal", "sleitnick/signal@2.0.1"], ["Trove", "sleitnick/trove@1.0.1"]]
 
 [[package]]
 name = "sleitnick/signal"
-version = "1.5.0"
+version = "2.0.1"
 dependencies = []
 
 [[package]]

--- a/wally.toml
+++ b/wally.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leostormer/ragdoll-system"
-version = "0.3.3"
+version = "0.3.4"
 registry = "https://github.com/UpliftGames/wally-index"
 realm = "shared"
 liscense = "MIT"

--- a/wally.toml
+++ b/wally.toml
@@ -9,5 +9,5 @@ description = "A ragdoll implementation on roblox. Works for R6 and R15 out of t
 exclude = ["dev", "docs", "roblox.yml", "selene.toml", "moonwave.toml", "dev.project.json", "Plugin", "CHANGELOG.md", "LICENSE"]
 
 [dependencies]
-Signal = "sleitnick/signal@1.5.0"
+Signal = "sleitnick/signal@2.0.1"
 Trove = "sleitnick/trove@1.0.1"


### PR DESCRIPTION
Resolves #4  by updating the ROOT_PART_PHYSICAL_PROPERTIES to use a valid density value and silence the warning mentioned.