### PR TITLE
Fix ragdoll replication bug

### DIFF
--- a/dev/client/init.client.lua
+++ b/dev/client/init.client.lua
@@ -1,3 +1,4 @@
+local Players = game:GetService("Players")
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
 local UserInputService = game:GetService("UserInputService")
 local RagdollSystem = require(ReplicatedStorage.Packages.RagdollSystem)
@@ -23,6 +24,24 @@ function toggle()
 	end
 end
 
+local function characterAdded(character: Model)
+	local ragdoll: RagdollSystem.Ragdoll?
+
+		while not ragdoll do task.wait()
+			ragdoll = RagdollSystem:getRagdoll(character)
+		end
+
+		print("Got ragdoll!")
+end
+
+local function playerAdded(player: Player)
+	if player.Character then
+		characterAdded(player.Character)
+	end
+
+	player.CharacterAdded:Connect(characterAdded)
+end
+
 local actions = {
 	[Enum.KeyCode.R] = collapse,
 	[Enum.KeyCode.L] = toggle,
@@ -37,3 +56,15 @@ UserInputService.InputBegan:Connect(function(inputObject, gameProcessedEvent)
 
 	actions[inputObject.KeyCode]()
 end)
+
+for _, player in Players:GetPlayers() do
+	local localPlayer = Players.LocalPlayer
+
+	if player == localPlayer then
+		continue
+	end
+
+	playerAdded(player)
+end
+
+Players.PlayerAdded:Connect(playerAdded)

--- a/lib/RagdollController/init.server.lua
+++ b/lib/RagdollController/init.server.lua
@@ -142,12 +142,20 @@ player.CharacterAdded:Connect(onCharacterAdded)
 player.CharacterRemoving:Connect(onCharacterRemoving)
 
 function onRagdollAdded(ragdollModel: Model)
+	if ragdollModel == player.Character then
+		return
+	end
+
 	ragdollModel:WaitForChild("Humanoid")
 	local ragdoll = RagdollFactory.wrap(ragdollModel)
 	RagdollSystem._ragdolls[ragdollModel] = ragdoll
 end
 
 function onRagdollRemoved(ragdollModel)
+	if ragdollModel == player.Character then
+		return
+	end
+
 	local ragdoll = RagdollSystem:getRagdoll(ragdollModel)
 	if ragdoll then
 		ragdoll:destroy()

--- a/lib/RagdollService.server.lua
+++ b/lib/RagdollService.server.lua
@@ -77,7 +77,28 @@ end)
 
 --Automated Ragdoll Construction
 function onRagdollAdded(ragdollModel)
-	RagdollSystem:addRagdoll(ragdollModel)
+	local player = Players:GetPlayerFromCharacter(ragdollModel)
+
+	if player then
+		local ragdoll = RagdollSystem:getPlayerRagdoll(player)
+		if ragdoll then
+			ragdoll:Destroy()
+		end
+
+		--for reasons I dont want to think about, the character model literally loses
+		--its head without this defer* if you use this system with imediate mode signal behavior
+		task.defer(function()
+			RagdollSystem:addPlayerRagdoll(player, ragdollModel)
+		end)
+
+		ragdollModel.AncestryChanged:Connect(function()
+			if not ragdollModel:IsDescendantOf(workspace) then
+				RagdollSystem:removePlayerRagdoll(player)
+			end
+		end)
+	else
+		RagdollSystem:addRagdoll(ragdollModel)
+	end
 end
 
 function onRagdollRemoved(ragdollModel)
@@ -93,20 +114,7 @@ CollectionService:GetInstanceRemovedSignal("Ragdoll"):Connect(onRagdollRemoved)
 
 function onPlayerAdded(player: Player)
 	player.CharacterAdded:Connect(function(character)
-		local ragdoll = RagdollSystem:getPlayerRagdoll(player)
-		if ragdoll then
-			ragdoll:Destroy()
-		end
-
-		--for reasons I dont want to think about, the character model literally loses
-		--its head without this defer* if you use this system with imediate mode signal behavior
-		task.defer(function()
-			RagdollSystem:addPlayerRagdoll(player, character)
-		end)
-	end)
-
-	player.CharacterRemoving:Connect(function(_character)
-		RagdollSystem:removePlayerRagdoll(player)
+		character:AddTag("Ragdoll")
 	end)
 end
 


### PR DESCRIPTION
I was trying to detect when other players ragdolled in my game when I realized that they didn't have a replicated ragdoll object hooked to their characters. This should implement a simple fix, but probably not the best way to do it.