### PR TITLE
Avatar joint upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.6.0
+### Added
+
+- Added support for Rigs that use the new AnimationConstraint in the avatar upgrade beta.
+
 ## 0.5.1
 ### Fixed
 

--- a/lib/RagdollFactory/R15RagdollBlueprint.lua
+++ b/lib/RagdollFactory/R15RagdollBlueprint.lua
@@ -1,5 +1,4 @@
 local Blueprint = require(script.Parent.Parent.Blueprint)
-local Ragdoll = require(script.Parent.Ragdoll)
 
 local SHOULDER_SOCKET_SETTINGS =
 	{ MaxFrictionTorque = 150, UpperAngle = 50, TwistLowerAngle = -70, TwistUpperAngle = 160 }
@@ -8,25 +7,6 @@ local HIP_SOCKET_SETTINGS = { MaxFrictionTorque = 150, UpperAngle = 40, TwistLow
 local KNEE_SOCKET_SETTINGS = { MaxFrictionTorque = 150, UpperAngle = 0, TwistLowerAngle = -80, TwistUpperAngle = 5 }
 local WRIST_SOCKET_SETTINGS = { MaxFrictionTorque = 50, UpperAngle = 10, TwistLowerAngle = -45, TwistUpperAngle = 5 }
 local ANKLE_SOCKET_SETTINGS = { MaxFrictionTorque = 50, UpperAngle = 10, TwistLowerAngle = -45, TwistUpperAngle = 5 }
-
-function insertNoCollisionConstraint(ragdoll, limb0, limb1)
-	local noCollisionConstraint = Ragdoll.NOCOLLISIONCONSTRAINT_TEMPLATE:Clone()
-	noCollisionConstraint.Part0 = limb0
-	noCollisionConstraint.Part1 = limb1
-	table.insert(ragdoll._noCollisionConstraints, noCollisionConstraint)
-	noCollisionConstraint.Parent = ragdoll._noCollisionConstraintFolder
-end
-
-function setupCollisionConstraints(ragdoll)
-	insertNoCollisionConstraint(ragdoll, ragdoll.Character.RightFoot, ragdoll.Character.RightUpperLeg)
-	insertNoCollisionConstraint(ragdoll, ragdoll.Character.RightUpperLeg, ragdoll.Character.UpperTorso)
-	insertNoCollisionConstraint(ragdoll, ragdoll.Character.RightLowerLeg, ragdoll.Character.UpperTorso)
-	insertNoCollisionConstraint(ragdoll, ragdoll.Character.LeftFoot, ragdoll.Character.LeftUpperLeg)
-	insertNoCollisionConstraint(ragdoll, ragdoll.Character.LeftUpperLeg, ragdoll.Character.UpperTorso)
-	insertNoCollisionConstraint(ragdoll, ragdoll.Character.LeftLowerLeg, ragdoll.Character.UpperTorso)
-	insertNoCollisionConstraint(ragdoll, ragdoll.Character.LeftHand, ragdoll.Character.LeftUpperArm)
-	insertNoCollisionConstraint(ragdoll, ragdoll.Character.RightHand, ragdoll.Character.RightUpperArm)
-end
 
 local R15RagdollBlueprint = setmetatable({
 	numJoints = 15, -- number of constraints created on an R15 Rig, this number was tested for.
@@ -69,7 +49,19 @@ function R15RagdollBlueprint.satisfiesRequirements(model: Model)
 end
 
 function R15RagdollBlueprint.finalTouches(ragdoll)
-	setupCollisionConstraints(ragdoll)
+	local isAvatarUpgrade = ragdoll.Character.Head.Neck:IsA("AnimationConstraint")
+	if isAvatarUpgrade then
+		return
+	end
+
+	ragdoll:_insertNoCollisionConstraint(ragdoll.Character.RightFoot, ragdoll.Character.RightUpperLeg)
+	ragdoll:_insertNoCollisionConstraint(ragdoll.Character.RightUpperLeg, ragdoll.Character.UpperTorso)
+	ragdoll:_insertNoCollisionConstraint(ragdoll.Character.RightLowerLeg, ragdoll.Character.UpperTorso)
+	ragdoll:_insertNoCollisionConstraint(ragdoll.Character.LeftFoot, ragdoll.Character.LeftUpperLeg)
+	ragdoll:_insertNoCollisionConstraint(ragdoll.Character.LeftUpperLeg, ragdoll.Character.UpperTorso)
+	ragdoll:_insertNoCollisionConstraint(ragdoll.Character.LeftLowerLeg, ragdoll.Character.UpperTorso)
+	ragdoll:_insertNoCollisionConstraint(ragdoll.Character.LeftHand, ragdoll.Character.LeftUpperArm)
+	ragdoll:_insertNoCollisionConstraint(ragdoll.Character.RightHand, ragdoll.Character.RightUpperArm)
 end
 
 return R15RagdollBlueprint :: Blueprint.Blueprint

--- a/lib/TableUtils.lua
+++ b/lib/TableUtils.lua
@@ -12,6 +12,16 @@ function TableUtils.filter<T>(list: { T }, filterfunction: (T) -> boolean): { T 
 	return filteredlist
 end
 
+function TableUtils.find<T>(array: { T }, filterFunction: (T) -> boolean)
+	for key, value in array do
+		if filterFunction(value) then
+			return key, value
+		end
+	end
+
+	return nil
+end
+
 function TableUtils.map<T, U>(list: { T }, mapfunction: (T) -> U): { U }
 	local mappedList = table.create(#list)
 

--- a/lib/Types.lua
+++ b/lib/Types.lua
@@ -15,7 +15,8 @@ export type RagdollInternals = {
 	_noCollisionConstraints: { NoCollisionConstraint },
 	_limbs: { BasePart },
 	_accessoryHandles: { BasePart },
-	_motor6Ds: { Motor6D },
+	_joints: { Motor6D | AnimationConstraint },
+	_insertNoCollisionConstraint: (self: RagdollInternals, limb0: BasePart, limb2: BasePart) -> (),
 }
 
 export type Ragdoll = {

--- a/wally.lock
+++ b/wally.lock
@@ -4,7 +4,7 @@ registry = "test"
 
 [[package]]
 name = "leostormer/ragdoll-system"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [["Signal", "sleitnick/signal@2.0.3"], ["Trove", "sleitnick/trove@1.5.0"]]
 
 [[package]]

--- a/wally.toml
+++ b/wally.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leostormer/ragdoll-system"
-version = "0.5.1"
+version = "0.6.0"
 registry = "https://github.com/UpliftGames/wally-index"
 realm = "shared"
 liscense = "MIT"


### PR DESCRIPTION
Adds support for rigs that use the new [AnimationConstraint](https://create.roblox.com/docs/reference/engine/classes/AnimationConstraint) instance introduced in the [Avatar Joint Upgrade Beta](https://devforum.roblox.com/t/studio-beta-avatar-joint-upgrade-enabling-physically-simulated-characters/3266099). Maintains support for rigs that use Motor6Ds. This time with a linear commit history and (hopefully) no spelling errors.